### PR TITLE
image: add heaps hxd.Pixels conversions

### DIFF
--- a/src/vision/ds/Image.hx
+++ b/src/vision/ds/Image.hx
@@ -839,8 +839,11 @@ abstract Image(Matrix<Null<Color>>) {
     }
     #end
     #if heaps
-    @:from public static function fromHeapsBitmapData(bitmapData:hxd.BitmapData):Image {
-        return ImageTools.fromHeapsBitmapData(bitmapData);
+    @:from public static function fromHeapsPixels(pixels:hxd.Pixels):Image {
+        return ImageTools.fromHeapsPixels(pixels);
+    }
+    @:to public function toHeapsPixels():hxd.Pixels {
+        return ImageTools.toHeapsPixels(cast this);
     }
     #end
 

--- a/src/vision/tools/ImageTools.hx
+++ b/src/vision/tools/ImageTools.hx
@@ -332,16 +332,28 @@ class ImageTools {
 	#end
 
 	#if heaps
-	public static function fromHeapsBitmapData(bitmap:hxd.BitmapData):Image {
-		var image = new Image(bitmap.width, bitmap.height);
-		bitmap.lock();
-		for (x in 0...bitmap.width) {
-			for (y in 0...bitmap.height) {
-				image.setPixel(x, y, bitmap.getPixel(x, y));
+	public static function fromHeapsPixels(pixels:hxd.Pixels):Image {
+		var image = new Image(pixels.width, pixels.height);
+		switch pixels.format {
+			case RGBA:
+			default:
+				throw "pixels format must be RGBA, currently: " + pixels.format;
+		}
+		for (x in 0...pixels.width) {
+			for (y in 0...pixels.height) {
+				image.setPixel(x, y, pixels.getPixel(x, y));
 			}
 		}
-		bitmap.unlock();
 		return image;
+	}
+	public static function toHeapsPixels(image:Image):hxd.Pixels {
+		var pixels = hxd.Pixels.alloc(image.width,image.height,RGBA);
+		for (x in 0...image.width) {
+			for (y in 0...pixels.height) {
+				pixels.setPixel(x,y,image.getPixel(x,y));
+			}
+		}
+		return pixels;
 	}
 	#end
 }

--- a/src/vision/tools/ImageTools.hx
+++ b/src/vision/tools/ImageTools.hx
@@ -335,7 +335,7 @@ class ImageTools {
 	public static function fromHeapsPixels(pixels:hxd.Pixels):Image {
 		var image = new Image(pixels.width, pixels.height);
 		switch pixels.format {
-			case RGBA:
+			case ARGB:
 			default:
 				throw "pixels format must be RGBA, currently: " + pixels.format;
 		}
@@ -347,7 +347,7 @@ class ImageTools {
 		return image;
 	}
 	public static function toHeapsPixels(image:Image):hxd.Pixels {
-		var pixels = hxd.Pixels.alloc(image.width,image.height,RGBA);
+		var pixels = hxd.Pixels.alloc(image.width,image.height,ARGB);
 		for (x in 0...image.width) {
 			for (y in 0...pixels.height) {
 				pixels.setPixel(x,y,image.getPixel(x,y));


### PR DESCRIPTION
Only ``hxd.Pixels`` is needed as that is the base class that holds texture pixel data and can be converted to and from easily with heaps functions.