### PR TITLE
add helper to get bytes in and out of Image.

### DIFF
--- a/src/vision/helpers/ImageBytes.hx
+++ b/src/vision/helpers/ImageBytes.hx
@@ -1,0 +1,20 @@
+package vision.helpers;
+
+// Module ImageBytes
+/**
+ Allows injection of Bytes data directly into the Image and direct extraction
+ **/
+@:access( vision.ds.Image.OFFSET )
+final imageOff = vision.ds.Image.OFFSET;
+inline 
+function imageLen( image: vision.ds.Image ): Int
+    return image.width * image.height * 4;
+inline
+function injectBytesInImage( bytes: haxe.io.Bytes, image: vision.ds.Image )
+    image.underlying.blit( imageOff, bytes, 0, imageLen( image ) );
+inline
+function extractBytesFromImage( image: vision.ds.Image ): haxe.io.Bytes {
+    var out = haxe.io.Bytes.alloc( imageLen( image ) );
+    out.blit( 0, image.underlying, imageOff, imageLen( image ) );
+    return out;
+}


### PR DESCRIPTION
Obvious issue is that to populate an Image you must call the constructor that initialises the whole ByteArray, but you want to inject the data so only want the OFFSET bytes initialised.  With large images on js initialising all the pixels when you will inject them is heavier.