### PR TITLE
Update MatrixOperationError.hx (cs, Java & Jvm error)

### DIFF
--- a/src/vision/exceptions/MatrixOperationError.hx
+++ b/src/vision/exceptions/MatrixOperationError.hx
@@ -12,10 +12,10 @@ class MatrixOperationError extends VisionException {
     	@param matrices the two offending matrices
     **/
     public function new(op:String, matrices:Array<Matrix2D>, offense:MatrixError) {
-        super(errorByType(op, matrices, offense), 'Matrix ${op.charAt(0).toUpperCase() + op.substr(1)} Error');
+        super(MatrixOperationError.errorByType(op, matrices, offense), 'Matrix ${op.charAt(0).toUpperCase() + op.substr(1)} Error');
     }
 
-    function errorByType(type:String, mats:Array<Matrix2D>, off:MatrixError):String {
+    public static function errorByType(type:String, mats:Array<Matrix2D>, off:MatrixError):String {
         var sign = "";
         switch type {
             case "mult" | "multiplication" | "Mult" | "Multiplication": sign = "×";


### PR DESCRIPTION
Yeah, there is some new errors going on here, but one new error done.

``src/vision/exceptions/MatrixOperationError.cs(10,105): error CS0027: Keyword `this' is not available in the current context ``